### PR TITLE
feat: add switch and switchCase treatment

### DIFF
--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -266,6 +266,16 @@ export default class Plugin {
     this.buildExpressionHandler(node, ['callee', 'arguments'], path, state);
   }
 
+  SwitchStatement(path, state) {
+    const { node } = path;
+    this.buildExpressionHandler(node, ['discriminant'], path, state);
+  }
+
+  SwitchCase(path, state) {
+    const { node } = path;
+    this.buildExpressionHandler(node, ['test'], path, state);
+  }
+
   ClassDeclaration(path, state) {
     const { node } = path;
     this.buildExpressionHandler(node, ['superClass'], path, state);

--- a/src/index.js
+++ b/src/index.js
@@ -99,6 +99,8 @@ export default function ({ types }) {
     'BinaryExpression',
     'NewExpression',
     'ClassDeclaration',
+    'SwitchStatement',
+    'SwitchCase',
   ];
 
   const ret = {

--- a/test/fixtures/switch/actual.js
+++ b/test/fixtures/switch/actual.js
@@ -1,0 +1,8 @@
+import { Select as AntdSelect } from 'antd';
+
+switch(AntdSelect){
+  case AntdSelect:
+    console.log('foo');
+  default:
+    console.log('bar')
+}

--- a/test/fixtures/switch/actual.js
+++ b/test/fixtures/switch/actual.js
@@ -1,8 +1,8 @@
-import { Select as AntdSelect } from 'antd';
+import { Select } from 'antd';
 
-switch(AntdSelect){
-  case AntdSelect:
-    console.log('foo');
-  default:
-    console.log('bar')
-}
+  switch(Select){
+    case Select:
+      console.log('foo');
+    default:
+      console.log('bar')
+  }

--- a/test/fixtures/switch/expected.js
+++ b/test/fixtures/switch/expected.js
@@ -11,4 +11,3 @@ switch (_select.default) {
   default:
     console.log('bar');
 }
-

--- a/test/fixtures/switch/expected.js
+++ b/test/fixtures/switch/expected.js
@@ -1,0 +1,14 @@
+"use strict";
+
+var _select = _interopRequireDefault(require("antd/lib/select"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+switch (_select.default) {
+  case _select.default:
+    console.log('foo');
+
+  default:
+    console.log('bar');
+}
+


### PR DESCRIPTION
When the switch statement is directly introduced, Babel plugin import does not convert. Now add ast conversion of switch

Scope of influence: switchcase, switchstatement